### PR TITLE
Try *all* scripts when passing in wildcards without --clobber

### DIFF
--- a/unrpyc.py
+++ b/unrpyc.py
@@ -104,7 +104,8 @@ def decompile_rpyc(input_filename, overwrite=False):
         ast = read_ast_from_file(in_file)
 
     if not overwrite and os.path.exists(out_filename):
-        sys.exit("Output file already exists. Pass --clobber to overwrite.")
+        print "Output file already exists. Pass --clobber to overwrite."
+        return # Don't stop decompiling if one file already exists
 
     with codecs.open(out_filename, 'w', encoding='utf-8') as out_file:
         decompiler.pretty_print_ast(out_file, ast)


### PR DESCRIPTION
Previously, passing the scripts as /path/to/scripts/*.rpyc would
cause sys.exit to be called if ANY of the corresponding .rpy files
already existed, which makes it harder to bulk-decompile directories
that contain some non-compiled files.
