### PR TITLE
Only check the first character of Python code for newlines

### DIFF
--- a/decompiler/__init__.py
+++ b/decompiler/__init__.py
@@ -443,7 +443,7 @@ class Decompiler(DecompilerBase):
             self.indent()
 
         code = ast.code.source
-        if '\n' in code or from_translate:
+        if code[0] == '\n' or from_translate:
             self.write("python")
             if early:
                 self.write(" early")

--- a/decompiler/sl2decompiler.py
+++ b/decompiler/sl2decompiler.py
@@ -160,10 +160,10 @@ class SL2Decompiler(DecompilerBase):
     def print_python(self, ast):
         self.indent()
 
-        # Extract the source code from the slast.SLPython object. If it's one line
-        # print it as a $ statement, else, print it as a python block
+        # Extract the source code from the slast.SLPython object. If it starts with a
+        # newline, print it as a python block, else, print it as a $ statement
         code = ast.code.source
-        if "\n" in code:
+        if code[0] == "\n":
             self.write("python:")
             self.indent_level += 1
             for line in code.splitlines():


### PR DESCRIPTION
It's possible for Python code from the $ statement to be multiline, so
checking for a newline anywhere isn't accurate. It seems that using the
python: block causes a newline to be inserted at the beginning of the
code, so check for that instead.