### PR TITLE
Restore special-casing of tag in SL2

### DIFF
--- a/decompiler/sl2decompiler.py
+++ b/decompiler/sl2decompiler.py
@@ -77,6 +77,10 @@ class SL2Decompiler(DecompilerBase):
             self.indent()
             self.write("%s %s" % (key, value))
 
+        if ast.tag:
+            self.indent()
+            self.write("tag %s" % ast.tag)
+
         # If we're decompiling screencode, print it. Else, insert a pass statement
         if self.decompile_screencode:
             self.print_nodes(ast.children)


### PR DESCRIPTION
The value of tag isn't stored in keyword (unlike the rest of them
that were recently removed), so restore its special-casing.