### PR TITLE
Check whether SL1 strings are Unicode

### DIFF
--- a/decompiler/screendecompiler.py
+++ b/decompiler/screendecompiler.py
@@ -73,16 +73,16 @@ class SLDecompiler(DecompilerBase):
         self.indent_level += 1
 
         # Print any keywords
-        if ast.tag:
+        if isinstance(ast.tag, unicode):
             self.indent()
             self.write("tag %s" % ast.tag)
-        if ast.zorder and ast.zorder != '0':
+        if isinstance(ast.zorder, unicode):
             self.indent()
             self.write("zorder %s" % simple_expression_guard(ast.zorder))
-        if ast.modal:
+        if isinstance(ast.modal, unicode):
             self.indent()
             self.write("modal %s" % simple_expression_guard(ast.modal))
-        if ast.variant and ast.variant != "None":
+        if isinstance(ast.variant, unicode):
             self.indent()
             self.write("variant %s" % simple_expression_guard(ast.variant))
 

--- a/decompiler/screendecompiler.py
+++ b/decompiler/screendecompiler.py
@@ -73,7 +73,7 @@ class SLDecompiler(DecompilerBase):
         self.indent_level += 1
 
         # Print any keywords
-        if isinstance(ast.tag, unicode):
+        if ast.tag:
             self.indent()
             self.write("tag %s" % ast.tag)
         if isinstance(ast.zorder, unicode):


### PR DESCRIPTION
Distinguish between an omitted value and a present default value by checking
what type of string it is (omitted values are normal strings, and present
default values are Unicode strings).