### PR TITLE
Don't add blank lines in python blocks

### DIFF
--- a/decompiler/__init__.py
+++ b/decompiler/__init__.py
@@ -452,6 +452,8 @@ class Decompiler(DecompilerBase):
 
         code = ast.code.source
         if code[0] == '\n' or from_translate:
+            if code[0] == '\n':
+                code = code[1:]
             self.write("python")
             if early:
                 self.write(" early")

--- a/decompiler/sl2decompiler.py
+++ b/decompiler/sl2decompiler.py
@@ -153,6 +153,7 @@ class SL2Decompiler(DecompilerBase):
         # newline, print it as a python block, else, print it as a $ statement
         code = ast.code.source
         if code[0] == "\n":
+            code = code[1:]
             self.write("python:")
             self.indent_level += 1
             for line in code.splitlines():


### PR DESCRIPTION
We add our own newline at the beginning of blocks, so the one already
present at the beginning of the code is redundant.