### PR TITLE
Remove spaces around equals signs for named arguments

### DIFF
--- a/decompiler/util.py
+++ b/decompiler/util.py
@@ -106,7 +106,7 @@ def reconstruct_arginfo(arginfo):
     for (name, val) in arginfo.arguments:
         rv.append(sep())
         if name is not None:
-            rv.append("%s = " % name)
+            rv.append("%s=" % name)
         rv.append(val)
     if arginfo.extrapos:
         rv.append(sep())


### PR DESCRIPTION
Any spaces after the equals sign for a named argument will end up in
the AST, so we shouldn't arbitrarily put them there.