### PR TITLE
Fix #34 (unknown node for OnEvent)

### DIFF
--- a/decompiler/sl2decompiler.py
+++ b/decompiler/sl2decompiler.py
@@ -199,6 +199,7 @@ class SL2Decompiler(DecompilerBase):
         self.write(name)
         self.print_arguments(ast.positional, ast.keyword, False)
     dispatch[(behavior.OnEvent, None)]          = (print_nochild, "on")
+    dispatch[(behavior.OnEvent, 0)]             = (print_nochild, "on")
     dispatch[(behavior.MouseArea, 0)]           = (print_nochild, "mousearea")
     dispatch[(sld.sl2add, None)]                = (print_nochild, "add")
     dispatch[(ui._hotbar, "hotbar")]            = (print_nochild, "hotbar")


### PR DESCRIPTION
Prior to RenPy's commit 9874bc4d, renpy.display.behavior.OnEvent had a
style of 0 instead of None. Because of that, we should handle both.