### PR TITLE
Add a "--comparable" switch

### DIFF
--- a/decompiler/__init__.py
+++ b/decompiler/__init__.py
@@ -36,11 +36,12 @@ __all__ = ["astdump", "codegen", "magic", "screendecompiler", "sl2decompiler", "
 
 def pprint(out_file, ast, indent_level=0,
            force_multiline_kwargs=True, decompile_screencode=True,
-           decompile_python=True):
+           decompile_python=True, comparable=False):
     Decompiler(out_file,
                force_multiline_kwargs=force_multiline_kwargs,
                decompile_screencode=decompile_screencode,
-               decompile_python=decompile_python).dump(ast, indent_level)
+               decompile_python=decompile_python,
+               comparable=comparable).dump(ast, indent_level)
 
 # Implementation
 
@@ -54,11 +55,12 @@ class Decompiler(DecompilerBase):
     dispatch = {}
 
     def __init__(self, out_file=None, force_multiline_kwargs=True, decompile_screencode=True,
-                 decompile_python=True, indentation = '    '):
+                 decompile_python=True, indentation = '    ', comparable=False):
         super(Decompiler, self).__init__(out_file, indentation)
         self.force_multiline_kwargs = force_multiline_kwargs
         self.decompile_screencode = decompile_screencode
         self.decompile_python = decompile_python
+        self.comparable = comparable
 
         self.paired_with = None
         self.with_consumed = True

--- a/decompiler/astdump.py
+++ b/decompiler/astdump.py
@@ -25,10 +25,10 @@ import inspect
 import codegen
 import ast as py_ast
 
-def pprint(out_file, ast, decompile_python=True):
+def pprint(out_file, ast, decompile_python=True, comparable=False):
     # The main function of this module, a wrapper which sets
     # the config and creates the AstDumper instance
-    AstDumper(out_file, decompile_python=decompile_python).dump(ast)
+    AstDumper(out_file, decompile_python=decompile_python, comparable=comparable).dump(ast)
 
 class AstDumper(object):
     """
@@ -40,10 +40,11 @@ class AstDumper(object):
     MAP_CLOSE = {list: ']', tuple: ')', set: '}', frozenset: '})'}
 
     def __init__(self, out_file=None, decompile_python=True,  
-                 indentation=u'    '):
+                 indentation=u'    ', comparable=False):
         self.indentation = indentation
         self.out_file = out_file or sys.stdout
         self.decompile_python = decompile_python
+        self.comparable = comparable
 
     def dump(self, ast):
         self.indent = 0
@@ -100,6 +101,18 @@ class AstDumper(object):
         self.ind(-1, ast)
         self.p('}')
 
+    def should_print_key(self, ast, key):
+        if key.startswith('_') or not hasattr(ast, key) or inspect.isroutine(getattr(ast, key)):
+            return False
+        elif not self.comparable:
+            return True
+        elif key == 'name':
+            return type(getattr(ast, key)) != tuple
+        elif key == 'linenumber' or key == 'loc' or key == 'serial' or key == 'filename' or key == 'location':
+            return False
+        else:
+            return True
+
     def print_object(self, ast):
         # handles the printing of anything unknown which inherts from object.
         # prints the values of relevant attributes in a dictionary-like way
@@ -114,7 +127,7 @@ class AstDumper(object):
                 self.p('>')
                 return
 
-        keys = list(i for i in dir(ast) if not i.startswith('_') and hasattr(ast, i) and not inspect.isroutine(getattr(ast, i)))
+        keys = list(i for i in dir(ast) if self.should_print_key(ast, i))
         if keys:
             self.p(' ')
         self.ind(1, keys)

--- a/decompiler/astdump.py
+++ b/decompiler/astdump.py
@@ -40,7 +40,7 @@ class AstDumper(object):
     MAP_CLOSE = {list: ']', tuple: ')', set: '}', frozenset: '})'}
 
     def __init__(self, out_file=None, decompile_python=True,  
-                 indentation=u'    ', comparable=False):
+                 comparable=False, indentation=u'    '):
         self.indentation = indentation
         self.out_file = out_file or sys.stdout
         self.decompile_python = decompile_python

--- a/unrpyc.py
+++ b/unrpyc.py
@@ -56,7 +56,7 @@ def read_ast_from_file(in_file):
     return stmts
 
 def decompile_rpyc(input_filename, overwrite=False, dump=False, decompile_screencode=True,
-                   decompile_python=True, force_multiline_kwargs=True):
+                   decompile_python=True, force_multiline_kwargs=True, comparable=False):
     # Output filename is input filename but with .rpy extension
     filepath, ext = path.splitext(input_filename)
     out_filename = filepath + ('.txt' if dump else '.rpy')
@@ -72,11 +72,11 @@ def decompile_rpyc(input_filename, overwrite=False, dump=False, decompile_screen
 
     with codecs.open(out_filename, 'w', encoding='utf-8') as out_file:
         if dump:
-            astdump.pprint(out_file, ast, decompile_python=decompile_python)
+            astdump.pprint(out_file, ast, decompile_python=decompile_python, comparable=comparable)
         else:
             decompiler.pprint(out_file, ast, force_multiline_kwargs=force_multiline_kwargs,
                                              decompile_screencode=decompile_screencode,
-                                             decompile_python=decompile_python)
+                                             decompile_python=decompile_python, comparable=comparable)
     return True
 
 def main():
@@ -100,6 +100,11 @@ def main():
     parser.add_argument('--single-line-screen-kwargs', dest='force_multiline_kwargs', action='store_false',
                         help="Only for decompiling, don't force all keyword arguments from screencode to different lines")
 
+    parser.add_argument('--comparable', dest='comparable', action='store_true',
+                        help="Modify the output to make comparing ast dumps easier. "
+                        "Currently, this has no effect when decompiling. "
+                        "When dumping the ast, this omits properties such as file names and modification times.")
+
     parser.add_argument('file', type=str, nargs='+', 
                         help="The filenames to decompile")
 
@@ -121,7 +126,8 @@ def main():
         try:
             correct = decompile_rpyc(filename, args.clobber, args.dump, decompile_screencode=args.decompile_screencode,
                                                                   decompile_python=args.decompile_python,
-                                                                  force_multiline_kwargs=args.force_multiline_kwargs)
+                                                                  force_multiline_kwargs=args.force_multiline_kwargs,
+                                                                  comparable=args.comparable)
         except Exception as e:
             print traceback.format_exc()
             bad += 1


### PR DESCRIPTION
Make it easier to compare AST dumps of different rpyc's by using the new
"--comparable" switch. Currently, its only effect is to suppress properties
such as file names and modification times from the dumps. In the future, I
plan to add other features to it, such as triggering the insertion of blank
lines to make line numbers match.