### PR TITLE
install fails with IOError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 def readme():
-    with open('README') as f:
+    with open('README.md') as f:
         return f.read()
 setup(
     name='unrpyc',


### PR DESCRIPTION
```
C:\>pip install git+https://github.com/CensoredUsername/unrpyc.git
Collecting git+https://github.com/CensoredUsername/unrpyc.git
Cloning https://github.com/CensoredUsername/unrpyc.git to c:\docume~1\user\locals~1\temp\pip-cpnkdg-build
Complete output from command python setup.py egg_info:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "c:\docume~1\user\locals~1\temp\pip-cpnkdg-build\setup.py", line 10,
in <module>
    long_description=readme(),
  File "c:\docume~1\user\locals~1\temp\pip-cpnkdg-build\setup.py", line 4, in readme
    with open('README') as f:
IOError: [Errno 2] No such file or directory: 'README'
```