### PR TITLE
add print TranslateEarlyBlock method

### DIFF
--- a/decompiler/__init__.py
+++ b/decompiler/__init__.py
@@ -812,6 +812,14 @@ class Decompiler(DecompilerBase):
         finally:
             self.in_init = in_init
 
+    @dispatch(renpy.ast.TranslateEarlyBlock)
+    def print_translateearlyblock(self, ast):
+        """
+        class TranslateEarlyBlock(TranslateBlock):
+        This is similar to the TranslateBlock, except it runs before deferred styles do.
+        """
+        print_translateblock(self,ast)
+
     # Screens
 
     @dispatch(renpy.ast.Screen)


### PR DESCRIPTION
Fix <<<COULD NOT DECOMPILE: Unknown AST node: <class '**renpy.ast.TranslateEarlyBlock**'>>>> issue
TranslateEarlyBlock is subclass of TranslateBlock 
Use `self.dispatch.get(type(ast), type(self).print_unknown)(self, ast)`  will miss it