### PR TITLE
Properly fix #121

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     description='Tool to decompile Ren\'Py compiled .rpyc script files.',
     long_description=readme(),
     url='https://github.com/CensoredUsername/unrpyc',
-    py_modules=['unrpyc'],
+    py_modules=['unrpyc', '.deobfuscate'],
     packages=['decompiler'],
-    scripts=['unrpyc.py', 'deobfuscate.py'],
+    scripts=['unrpyc.py'],
     zip_safe=False,
 )


### PR DESCRIPTION
Turns out that wasn't the place to put it, as it'd put `deobfuscate.py` into `/usr/bin/`.