### PR TITLE
Names for user-defined screen displayable objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ optional arguments:
                         less cluttered.
   --try-harder          Tries some workarounds against common obfuscation
                         methods. This is a lot slower.
-  --sl-displayable-classes
+  --sl-displayable-classes CLASSNAME=NEWNAME-CHILDREN ...
                         Accepts mapping separated by '=',
                         where the first argument is the name
                         of the user-defined displayable object,

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ usage: unrpyc.py [-h] [-c] [-d] [-p {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}]
                  [-t TRANSLATION_FILE] [-T WRITE_TRANSLATION_FILE]
                  [-l LANGUAGE] [--sl1-as-python] [--comparable] [--no-pyexpr]
                  [--tag-outside-block] [--init-offset] [--try-harder]
+                 [--sl-displayable-classes CLASSNAME=NEWNAME-CHILDREN ...]
                  file [file ...]
 
 Decompile .rpyc/.rpymc files
@@ -84,6 +85,16 @@ optional arguments:
                         less cluttered.
   --try-harder          Tries some workarounds against common obfuscation
                         methods. This is a lot slower.
+  --sl-displayable-classes
+                        Accepts mapping separated by '=',
+                        where the first argument is the name
+                        of the user-defined displayable object,
+                        and the second argument is a string separated by '-',
+                        containing the name of the displayable object
+                        and the argument of the child displayable objects.
+                        Also the second argument can contain only the name
+                        of the object. In this case the child object argument
+                        will be set to 'many'.
 
 ```
 

--- a/decompiler/__init__.py
+++ b/decompiler/__init__.py
@@ -41,9 +41,11 @@ __all__ = ["astdump", "codegen", "magic", "screendecompiler", "sl2decompiler", "
 # Main API
 
 def pprint(out_file, ast, indent_level=0,
-           decompile_python=False, printlock=None, translator=None, init_offset=False, tag_outside_block=False):
+           decompile_python=False, printlock=None, translator=None,
+           init_offset=False, tag_outside_block=False, sl_classes=None):
     Decompiler(out_file, printlock=printlock,
-               decompile_python=decompile_python, translator=translator).dump(ast, indent_level, init_offset, tag_outside_block)
+               decompile_python=decompile_python,
+               translator=translator, sl_classes=sl_classes).dump(ast, indent_level, init_offset, tag_outside_block)
 
 # Implementation
 
@@ -57,10 +59,12 @@ class Decompiler(DecompilerBase):
     dispatch = Dispatcher()
 
     def __init__(self, out_file=None, decompile_python=False,
-                 indentation = '    ', printlock=None, translator=None):
+                 indentation = '    ', printlock=None,
+                 translator=None, sl_classes=None):
         super(Decompiler, self).__init__(out_file, indentation, printlock)
         self.decompile_python = decompile_python
         self.translator = translator
+        self.sl_classes = sl_classes
 
         self.paired_with = False
         self.say_inside_menu = None
@@ -786,7 +790,7 @@ class Decompiler(DecompilerBase):
     # actually belongs inside of the Menu statement.
     def say_belongs_to_menu(self, say, menu):
         return (not say.interact and say.who is not None and
-            say.with_ is None and 
+            say.with_ is None and
             (not hasattr(say, "attributes") or say.attributes is None) and
             isinstance(menu, renpy.ast.Menu) and
             menu.items[0][2] is not None and
@@ -939,7 +943,8 @@ class Decompiler(DecompilerBase):
                                     self.linenumber,
                                     self.skip_indent_until_write,
                                     self.printlock,
-                                    self.tag_outside_block)
+                                    self.tag_outside_block,
+                                    self.sl_classes)
             self.skip_indent_until_write = False
         else:
             self.print_unknown(screen)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
         return f.read()
 setup(
     name='unrpyc',
-    version='0.1',
+    version='0.1.1',
     description='Tool to decompile Ren\'Py compiled .rpyc script files.',
     long_description=readme(),
     url='https://github.com/CensoredUsername/unrpyc',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
         return f.read()
 setup(
     name='unrpyc',
-    version='0.1.1',
+    version='0.1.2',
     description='Tool to decompile Ren\'Py compiled .rpyc script files.',
     long_description=readme(),
     url='https://github.com/CensoredUsername/unrpyc',

--- a/un.rpyc/unrpyc-compile.py
+++ b/un.rpyc/unrpyc-compile.py
@@ -87,7 +87,7 @@ def ensure_dir(filename):
     if dir and not path.exists(dir):
         os.makedirs(dir)
 
-def decompile_rpyc(data, abspath, init_offset):
+def decompile_rpyc(data, abspath, init_offset, sl_classes):
     # Output filename is input filename but with .rpy extension
     filepath, ext = path.splitext(abspath)
     out_filename = filepath + ('.rpym' if ext == ".rpymc" else ".rpy")
@@ -96,7 +96,7 @@ def decompile_rpyc(data, abspath, init_offset):
 
     ensure_dir(out_filename)
     with codecs.open(out_filename, 'w', encoding='utf-8') as out_file:
-        decompiler.pprint(out_file, ast, init_offset=init_offset)
+        decompiler.pprint(out_file, ast, init_offset=init_offset, sl_classes=sl_classes)
     return True
 
 def decompile_game():
@@ -106,10 +106,10 @@ def decompile_game():
     ensure_dir(logfile)
     with open(logfile, "w") as f:
         f.write("Beginning decompiling\n")
-
+        sl_classes = {}  # Enter if available for a particular game.
         for abspath, fn, dir, data in sys.files:
             try:
-                decompile_rpyc(data, abspath, sys.init_offset)
+                decompile_rpyc(data, abspath, sys.init_offset, sl_classes)
             except Exception, e:
                 f.write("\nFailed at decompiling {0}\n".format(abspath))
                 traceback = sys.modules['traceback']

--- a/unrpyc.py
+++ b/unrpyc.py
@@ -297,6 +297,8 @@ def main():
             return (_key, (name, children))
         return (_key, (_value, "many"))
 
+    if args.sl_classes is None:
+        args.sl_classes = []
     args.sl_classes = dict(map(_parse_sl_arg_string, args.sl_classes))
 
     # Expand wildcards


### PR DESCRIPTION
Added the ability to pass the names of screen displayable objects added by game authors via **renpy.register_sl_displayable**.

Examples:
```
python unrpyc.py filename1 filename2 --sl-displayable-classes SomeDispClass=nameInScreen-many
```
```
python unrpyc.py filename1 filename2 --sl-displayable-classes SomeDispClass=nameInScreen-1
```
```
python unrpyc.py filename1 filename2 --sl-displayable-classes SomeDispClass=nameInScreen
```