### PR TITLE
fixes glob return behavior

### DIFF
--- a/unrpyc.py
+++ b/unrpyc.py
@@ -357,7 +357,9 @@ def main():
     def glob_or_complain(inpath):
         """Expands wildcards and casts output to pathlike state."""
         retval = [Path(elem).resolve(strict=True) for elem in glob.glob(inpath)]
-        return retval if retval else print(f"File not found: {inpath}")
+        if not retval:
+            print(f"Input path not found: {inpath}")
+        return retval
 
     def traverse(inpath):
         """


### PR DESCRIPTION
A invalid path input resulted in a return of 'None' from 'glob'. The followup error msg was so unclear.
-  now return is either empty list or one with pathlikes

----
I'm just not sure if the strict in resolve() should be removed. Depends if the glob() output really legit is or unsure.
