### PR TITLE
Dev endreport and app info

### DIFF
--- a/deobfuscate.py
+++ b/deobfuscate.py
@@ -38,7 +38,7 @@ import struct
 import base64
 from collections import Counter
 from decompiler.renpycompat import pickle_safe_loads
-import unrpyc
+from unrpyc import DeobfuscationError, printlock
 
 
 # Extractors are simple functions of (fobj, slotno) -> bytes
@@ -293,7 +293,7 @@ def read_ast(f):
 
     if not raw_datas:
         diagnosis.append("All strategies failed. Unable to extract data")
-        raise ValueError("\n".join(diagnosis))
+        raise DeobfuscationError("\n  ".join(diagnosis))
 
     if len(raw_datas) != 1:
         diagnosis.append("Strategies produced different results. Trying all options")
@@ -306,12 +306,12 @@ def read_ast(f):
             diagnosis.append(e.message)
         else:
             diagnosis.extend(d)
-            with unrpyc.printlock:
-                print("\n".join(diagnosis))
+            with printlock:
+                print("\n  ".join(diagnosis))
             return stmts
 
     diagnosis.append("All strategies failed. Unable to deobfuscate data")
-    raise ValueError("\n".join(diagnosis))
+    raise DeobfuscationError("\n".join(diagnosis))
 
 
 def try_decrypt_section(raw_data):

--- a/unrpyc.py
+++ b/unrpyc.py
@@ -20,6 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
+__title__ = "Unrpyc"
+__version__ = 'v2.1.dev'
+__url__ = "https://github.com/CensoredUsername/unrpyc"
+
+
 import sys
 import argparse
 from pathlib import Path
@@ -234,8 +240,9 @@ def worker(arg_tup):
 
 def main():
     if not sys.version_info[:2] >= (3, 9):
-        raise Exception("Must be executed in Python 3.9 or later.\n"
-                        f"You are running {sys.version}")
+        raise RuntimeError(
+            f"'{__title__} {__version__}' must be executed in Python 3.9 or later.\n"
+            f"You are running {sys.version}")
 
     # argparse usage: python3 unrpyc.py [-c] [--try-harder] [-d] [-p] file [file ...]
     cc_num = cpu_count()
@@ -341,6 +348,11 @@ def main():
         "and the second argument is a string containing the name of the displayable, "
         "potentially followed by a '-', and the amount of children the displayable takes"
         "(valid options are '0', '1' or 'many', with 'many' being the default)")
+
+    ap.add_argument(
+        '--version',
+        action='version',
+        version=f"{__title__} {__version__}")
 
     args = ap.parse_args()
 

--- a/unrpyc.py
+++ b/unrpyc.py
@@ -37,9 +37,14 @@ import zlib
 try:
     from multiprocessing import Pool, Lock, Manager, cpu_count
 except ImportError:
+    traceback.print_exc()
+
     # Mock required support when multiprocessing is unavailable
     def cpu_count():
         return 1
+
+    def Manager():
+        return sys.modules[__name__]
 
     class Lock:
         def __enter__(self):
@@ -50,6 +55,8 @@ except ImportError:
             pass
         def release(self):
             pass
+
+    dict = dict
 
 import decompiler
 import deobfuscate


### PR DESCRIPTION
See  #189

Add/update app infos
- add dunders for central info access
- add version to argparse
- change exception in py-version check

Refactoring of result system and endreport
- adds mp.manager for data syncing
- result counting in single dict
- more result types
- adds custom exception for wrong rpyc header

---

~Outstanding:~
- [x] Mock upgrade (Fun-fact: multiprocessing is since last spring in renpy included, but **_not_** in v8.0 - such luck!)
- [x] Results of deobfucate.py falls still through the counter system.(same as before this pull req)

Would be nice if you could take also a look at the outstanding issues. ~Could be a bit finicky where to put the result counters because of deobfuscate.py.~