### PR TITLE
Add guards for unusable CLI arg combinations

### DIFF
--- a/unrpyc.py
+++ b/unrpyc.py
@@ -351,21 +351,19 @@ def main():
     if (args.no_pyexpr or args.comparable) and not args.dump:
         raise ap.error(
             "Arguments 'comparable' and 'no_pyexpr' are not usable without 'dump'.")
-        return
 
     if ((args.try_harder or args.dump)
             and (args.write_translation_file or args.translation_file or args.language)):
         raise ap.error(
             "Arguments 'try_harder' and/or 'dump' are not usable with the translation "
             "feature.")
-        return
 
     # Fail early to avoid wasting time going through the files
     if (args.write_translation_file
             and not args.clobber
             and args.write_translation_file.exists()):
-        print("Output translation file already exists. Pass --clobber to overwrite.")
-        return
+        raise ap.error(
+            "Output translation file already exists. Pass --clobber to overwrite.")
 
     if args.translation_file:
         with args.translation_file.open('rb') as in_file:

--- a/unrpyc.py
+++ b/unrpyc.py
@@ -305,7 +305,7 @@ def main():
         '--language',
         dest='language',
         action='store',
-        default='english',
+        default=None,
         help="If writing a translation file, the language of the translations to write")
 
     ap.add_argument(
@@ -346,10 +346,24 @@ def main():
 
     args = ap.parse_args()
 
+    # Catch impossible arg combinations with clear info, so they do not produce unclear
+    # errors or fail silent
+    if (args.no_pyexpr or args.comparable) and not args.dump:
+        raise ap.error(
+            "Arguments 'comparable' and 'no_pyexpr' are not usable without 'dump'.")
+        return
+
+    if ((args.try_harder or args.dump)
+            and (args.write_translation_file or args.translation_file or args.language)):
+        raise ap.error(
+            "Arguments 'try_harder' and/or 'dump' are not usable with the translation "
+            "feature.")
+        return
+
+    # Fail early to avoid wasting time going through the files
     if (args.write_translation_file
-        and not args.clobber
+            and not args.clobber
             and args.write_translation_file.exists()):
-        # Fail early to avoid wasting time going through the files
         print("Output translation file already exists. Pass --clobber to overwrite.")
         return
 


### PR DESCRIPTION
@ #211 
I didn't add any other guards for translation args, because this feat, as discussed, is at given time about to change. In addition, this three args manage to produce alone five bad combinations between themselves i am aware of.

Args _init-offset_ and _sl-displayable_ i could not check as i have no testcases for them, but from the code i see so far no possible problems.