### PR TITLE
Better un.rpy file header

### DIFF
--- a/un.rpyc/compile.py
+++ b/un.rpyc/compile.py
@@ -165,8 +165,8 @@ from renpy.game import script
 
 decompiler_rpyb = p.ExecTranspile(base + "(None, [])", (decompiler_items,))
 
-rpy_base = """
-init python early hide:
+rpy_base = """\
+python early hide:
 
     import sys
     renpy_modules = sys.modules.copy()


### PR DESCRIPTION
This is nitpicking.
The `init python early` syntax is redundent because it wraps the early AST node inside an init AST node for no reason : whatever it's wrapped in, the early node is executed when the file gets parsed. And it is contradictory to state that your code executes both at early/parse time and at init time, which are two very different times !

Also avoids an ugly starting linebreak.