### PR TITLE
Context pattern: Endreport and app info

### DIFF
--- a/deobfuscate.py
+++ b/deobfuscate.py
@@ -294,6 +294,7 @@ def read_ast(f, context):
 
     if not raw_datas:
         diagnosis.append("All strategies failed. Unable to extract data")
+        context.set_state('spoofed')
         raise ValueError("\n".join(diagnosis))
 
     if len(raw_datas) != 1:
@@ -311,6 +312,7 @@ def read_ast(f, context):
             return stmts
 
     diagnosis.append("All strategies failed. Unable to deobfuscate data")
+    context.set_state('spoofed')
     raise ValueError("\n".join(diagnosis))
 
 

--- a/unrpyc.py
+++ b/unrpyc.py
@@ -485,12 +485,13 @@ def main():
         f"  > {plural_fmt(state_count['skip'])} already exist and have been skipped.\n"
     )
     # add pointers if we encounter problems
-    skipped = ("To overwrite existing files use option '--clopper'. "
+    skipped = ("To overwrite existing files use option '--clobber'. "
                if state_count['skip'] != 0 else "")
-    spoofed = ("In case of manipulations can be option '--try-harder' attempted."
-               if state_count['spoofed'] != 0 else "")
-    errors = ("Errors where found. Check the exceptions in the log for addition info about them."
-              if state_count['fail'] != 0 else "")
+    spoofed = (
+        "In case of manipulation, the --try-harder option can be attempted."
+        if state_count['spoofed'] != 0 else "")
+    errors = ("Errors were found. Check the exceptions in the log for more info about this."
+        if state_count['fail'] != 0 else "")
     print(endreport, skipped, spoofed, errors)
 
 if __name__ == '__main__':

--- a/unrpyc.py
+++ b/unrpyc.py
@@ -20,6 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
+__title__ = "Unrpyc"
+__version__ = 'v2.0.2.dev'
+__url__ = "https://github.com/CensoredUsername/unrpyc"
+
+
 import argparse
 import glob
 import struct
@@ -242,8 +248,9 @@ def worker(arg_tup):
 
 def main():
     if not sys.version_info[:2] >= (3, 9):
-        raise Exception("Must be executed in Python 3.9 or later.\n"
-                        f'You are running {sys.version}')
+        raise RuntimeError(
+            f"'{__title__} {__version__}' must be executed in Python 3.9 or later.\n"
+            f"You are running {sys.version}")
 
     # argparse usage: python3 unrpyc.py [-c] [--try-harder] [-d] [-p] file [file ...]
     cc_num = cpu_count()
@@ -350,10 +357,15 @@ def main():
         "potentially followed by a '-', and the amount of children the displayable takes"
         "(valid options are '0', '1' or 'many', with 'many' being the default)")
 
+    ap.add_argument(
+        '--version',
+        action='version',
+        version=f"{__title__} {__version__}")
+
     args = ap.parse_args()
 
-    # Catch impossible arg combinations with clear info, so they do not produce unclear
-    # errors or fail silent
+    # Catch impossible arg combinations so they don't produce strange errors or fail silent;
+    # output clear infos
     if (args.no_pyexpr or args.comparable) and not args.dump:
         raise ap.error(
             "Arguments 'comparable' and 'no_pyexpr' are not usable without 'dump'.")
@@ -384,7 +396,8 @@ def main():
 
     def glob_or_complain(inpath):
         """Expands wildcards and casts output to pathlike state."""
-        retval = [Path(elem).resolve(strict=True) for elem in glob.glob(inpath, recursive=True)]
+        retval = [Path(elem).resolve(strict=True)
+                  for elem in glob.glob(inpath, recursive=True)]
         if not retval:
             print(f'Input path not found: {inpath}')
         return retval
@@ -414,8 +427,8 @@ def main():
         print("Found no script files to decompile.")
         return
 
-    # If a big file starts near the end, there could be a long time with only one thread running,
-    # which is inefficient. Avoid this by starting big files first.
+    # If a big file starts near the end, there could be a long time with only one thread
+    # running, which is inefficient. Avoid this by starting big files first.
     worklist.sort(key=lambda x: x.stat().st_size, reverse=True)
     worklist = [(args, x) for x in worklist]
 

--- a/unrpyc.py
+++ b/unrpyc.py
@@ -76,7 +76,7 @@ def read_ast_from_file(in_file, context):
     # v1 files are just a zlib compressed pickle blob containing some data and the ast
     # v2 files contain a basic archive structure that can be parsed to find the same blob
     raw_contents = in_file.read()
-
+    l1_start = raw_contents[:50]
     is_rpyc_v1 = False
 
     if not raw_contents.startswith(b"RENPY RPC2"):
@@ -110,7 +110,8 @@ def read_ast_from_file(in_file, context):
         if 1 not in chunks:
             raise BadRpycException(
                 "Unable to find the right slot to load from the rpyc file. The file header "
-                "structure has been changed.")
+                "structure has been changed."
+                f"File header:{l1_start}")
 
         contents = chunks[1]
 


### PR DESCRIPTION
Integrate endreport and info code as discussed in #219

- GH diff makes it look as if the `worker()` func was moved, but in reality it was `parse_sl_custom_names()`, as it was placed between the other four which are all related to each other.
- result state counting was removed from `write_translation_file()`, because in the TL refactoring this is anyway a moot point