### PR TITLE
Some renpy 8.3.7+ fixes

### DIFF
--- a/decompiler/__init__.py
+++ b/decompiler/__init__.py
@@ -404,7 +404,7 @@ class Decompiler(DecompilerBase):
         for i, (condition, block) in enumerate(ast.entries):
             # The unicode string "True" is used as the condition for else:.
             # But if it's an actual expression, it's a renpy.ast.PyExpr
-            if (i + 1) == len(ast.entries) and not isinstance(condition, renpy.ast.PyExpr):
+            if (i + 1) == len(ast.entries) and condition == "None":
                 self.indent()
                 self.write("else:")
             else:
@@ -756,7 +756,7 @@ class Decompiler(DecompilerBase):
     @dispatch(renpy.ast.UserStatement)
     def print_userstatement(self, ast):
         self.indent()
-        self.write(ast.line)
+        self.write(ast.line.strip(' '))
 
         # block attribute since 6.13.0
         if ast.block is not None:

--- a/decompiler/__init__.py
+++ b/decompiler/__init__.py
@@ -404,7 +404,7 @@ class Decompiler(DecompilerBase):
         for i, (condition, block) in enumerate(ast.entries):
             # The unicode string "True" is used as the condition for else:.
             # But if it's an actual expression, it's a renpy.ast.PyExpr
-            if (i + 1) == len(ast.entries) and condition == "None":
+            if (i + 1) == len(ast.entries) and not isinstance(condition, (renpy.ast.PyExpr, renpy.astsupport.PyExpr)):
                 self.indent()
                 self.write("else:")
             else:

--- a/decompiler/util.py
+++ b/decompiler/util.py
@@ -362,7 +362,7 @@ def reconstruct_arginfo(arginfo):
     rv = ["("]
     sep = First("", ", ")
 
-    if hasattr(arginfo, 'starred_indexes'):
+    if not hasattr(arginfo, 'extrapos'):
         # ren'py 7.5 and above, PEP 448 compliant
         for i, (name, val) in enumerate(arginfo.arguments):
             rv.append(sep())


### PR DESCRIPTION
What's done:

- Fixed reconstruct_arginfo compability
- Add some new classes and new properties for old classes for combability reasons
- Fixed some reduce/getstate functions for accepting new renpy 8.3.7+ attributes
- Added/fixed some ast nodes:
- - Added TranslateSay
- - Improved UserStatement(strip leading whitespaces)
- - Fixed BaseDecompilrer.print_lex(better compability)
- - Fixed atl If statement else branch detection(maybe need to review it more deeply)
- - Fixed python block([source may be indented ](https://github.com/renpy/renpy/blob/3972ea25bbbe3e9172b09c88f269441600271ce5/renpy/python.py#L1098) )