### PR TITLE
Updated to support latest Ren'Py versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 *.swp
 *.pyc
 *.pyo

--- a/decompiler/__init__.py
+++ b/decompiler/__init__.py
@@ -624,7 +624,11 @@ class Decompiler(DecompilerBase):
         self.indent()
         self.write("menu")
         if self.label_inside_menu is not None:
-            self.write(f' {self.label_inside_menu.name}')
+            # Get the label name (using helper for Ren'Py 8.5+ compatibility)
+            label_name = get_node_name(self.label_inside_menu)
+            # Only write the label name if it exists and is not None
+            if label_name is not None:
+                self.write(f' {label_name}')
             self.label_inside_menu = None
 
         # arguments attribute added in 7.1.4

--- a/decompiler/magic.py
+++ b/decompiler/magic.py
@@ -130,6 +130,127 @@ FakeClass = FakeClassType("FakeClass", (), {"__doc__": """
 A barebones instance of :class:`FakeClassType`. Inherit from this to create fake classes.
 """}, module=__name__)
 
+# Known optional attributes in Ren'Py 8.5+ AST nodes with their default values
+# Ren'Py 8.5+ uses __slots__ with cslots optimization that doesn't pickle default values
+RENPY_AST_DEFAULTS = {
+    # Common attributes (Node base class)
+    'atl': None,
+    'expression': False,
+    'arguments': None,
+    'parameters': None,
+    'paired': None,
+    'hide': False,
+    'store': 'store',
+    'name': None,
+    '_name': None,
+    'name_version': 0,
+    'name_serial': 0,
+    'global_label': '',
+    'block': [],
+    
+    # Say attributes
+    'who': None,
+    'what': '',
+    'with_': None,
+    'interact': True,
+    'attributes': None,
+    'temporary_attributes': None,
+    'rollback': 'normal',
+    'identifier': None,
+    
+    # Image/Scene/Show attributes
+    'imspec': None,
+    'layer': 'master',
+    'at_list': [],
+    'behind': [],
+    'as_': None,
+    'atl_transform': None,
+    
+    # Menu attributes
+    'items': [],
+    'set': None,
+    'has_caption': False,
+    'caption_block': None,
+    'item_arguments': None,
+    'nvl': False,
+    
+    # Init attributes
+    'priority': 0,
+    
+    # Python/Code attributes
+    'code': None,
+    'source': '',
+    
+    # Screen attributes
+    'modal': None,
+    'zorder': None,
+    'tag': None,
+    'variant': None,
+    'predict': None,
+    'sensitive': None,
+    'layer': 'screens',
+    'roll_forward': None,
+    
+    # User statement
+    'translatable': False,
+    'translation_relevant': False,
+    'subparses': [],
+    'parsed': None,
+    
+    # Translate
+    'alternate': None,
+    'language': None,
+    
+    # Style attributes (Ren'Py 8.5+)
+    'parent': None,
+    'take': None,
+    'clear': False,
+    'properties': [],
+    'delattr': [],
+    
+    # Jump/Call attributes
+    'target': None,
+    'expression': False,
+    'from_expression': None,
+    
+    # Label attributes
+    'hide': False,
+    
+    # If/While attributes
+    'entries': [],
+    'condition': None,
+    
+    # Return attributes
+    'expression': None,
+    
+    # Transform attributes
+    'varname': None,
+    
+    # Default/Define attributes
+    'operator': '=',
+    'index': None,
+    
+    # ATL attributes
+    'loc': (None, 0),
+    'statements': [],
+    
+    # Screen language attributes
+    'keyword': [],
+    'children': [],
+    'positional': [],
+    'displayable': None,
+    'style': None,
+    'variable': None,
+    
+    # Testcase attributes
+    'label': None,
+    'right': False,
+    
+    # Translation attributes
+    'identifier': None,
+    'block': [],
+}
+
 class FakeStrict(FakeClass, object):
     def __new__(cls, *args, **kwargs):
         self = FakeClass.__new__(cls)
@@ -154,6 +275,12 @@ class FakeStrict(FakeClass, object):
 
         if slotstate:
             self.__dict__.update(slotstate)
+
+    def __getattr__(self, name):
+        # For Ren'Py 8.5+ compatibility: return default values for known optional attributes
+        if name in RENPY_AST_DEFAULTS:
+            return RENPY_AST_DEFAULTS[name]
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
 class FakeWarning(FakeClass, object):
     def __new__(cls, *args, **kwargs):

--- a/decompiler/sl2decompiler.py
+++ b/decompiler/sl2decompiler.py
@@ -29,6 +29,17 @@ from renpy.text import text
 from renpy.sl2 import sldisplayables as sld
 from renpy.display import layout, behavior, im, motion, dragdrop, transform
 
+# Helper to check if a value is a PyExpr (handles both renpy.ast.PyExpr and renpy.astsupport.PyExpr)
+def is_pyexpr(value):
+    """Check if value is a PyExpr from either renpy.ast or renpy.astsupport module."""
+    val_type = type(value)
+    if isinstance(value, PyExpr):
+        return True
+    # Check by class name in case the class is from renpy.astsupport (Ren'Py 8.5+)
+    if val_type.__name__ in ('PyExpr', 'PyExprAstSupport'):
+        return True
+    return False
+
 # Main API
 
 def pprint(out_file, ast, options,
@@ -163,11 +174,12 @@ class SL2Decompiler(DecompilerBase):
     def print_python(self, ast):
         self.indent()
 
-        # Extract the source code from the slast.SLPython object. If it starts with a
-        # newline, print it as a python block, else, print it as a $ statement
+        # Extract the source code from the slast.SLPython object. If it contains
+        # newlines, print it as a python block, else, print it as a $ statement
+        # In Ren'Py 8.5+, the source may start with spaces/indentation instead of newline
         code = ast.code.source
-        if code.startswith("\n"):
-            code = code[1:]
+        if '\n' in code:
+            code = code.lstrip()
             self.write("python:")
             with self.increase_indent():
                 self.write_lines(split_logical_lines(code))
@@ -186,7 +198,7 @@ class SL2Decompiler(DecompilerBase):
         self.indent()
         self.write("use ")
         args = reconstruct_arginfo(ast.args)
-        if isinstance(ast.target, PyExpr):
+        if is_pyexpr(ast.target):
             self.write(f'expression {ast.target}')
             if args:
                 self.write(" pass ")

--- a/decompiler/sl2decompiler.py
+++ b/decompiler/sl2decompiler.py
@@ -172,6 +172,7 @@ class SL2Decompiler(DecompilerBase):
 
     @dispatch(sl2.slast.SLPython)
     def print_python(self, ast):
+        import textwrap
         self.indent()
 
         # Extract the source code from the slast.SLPython object. If it contains
@@ -179,7 +180,10 @@ class SL2Decompiler(DecompilerBase):
         # In Ren'Py 8.5+, the source may start with spaces/indentation instead of newline
         code = ast.code.source
         if '\n' in code:
-            code = code.lstrip()
+            # Strip leading blank lines, then dedent to remove common indentation
+            code = code.lstrip('\n')
+            code = textwrap.dedent(code)
+            code = code.strip('\n')
             self.write("python:")
             with self.increase_indent():
                 self.write_lines(split_logical_lines(code))

--- a/decompiler/testcasedecompiler.py
+++ b/decompiler/testcasedecompiler.py
@@ -46,12 +46,16 @@ class TestcaseDecompiler(DecompilerBase):
 
     @dispatch(testast.Python)
     def print_python(self, ast):
+        import textwrap
         self.indent()
         code = ast.code.source
         # In Ren'Py 8.5+, the source may start with spaces/indentation instead of newline
         # Check if there are any newlines (indicating multiline) rather than checking first char
         if '\n' in code:
-            code = code.lstrip()
+            # Strip leading blank lines, then dedent to remove common indentation
+            code = code.lstrip('\n')
+            code = textwrap.dedent(code)
+            code = code.strip('\n')
             self.write("python:")
             with self.increase_indent():
                 self.write_lines(split_logical_lines(code))

--- a/decompiler/testcasedecompiler.py
+++ b/decompiler/testcasedecompiler.py
@@ -48,10 +48,13 @@ class TestcaseDecompiler(DecompilerBase):
     def print_python(self, ast):
         self.indent()
         code = ast.code.source
-        if code[0] == '\n':
+        # In Ren'Py 8.5+, the source may start with spaces/indentation instead of newline
+        # Check if there are any newlines (indicating multiline) rather than checking first char
+        if '\n' in code:
+            code = code.lstrip()
             self.write("python:")
             with self.increase_indent():
-                self.write_lines(split_logical_lines(code[1:]))
+                self.write_lines(split_logical_lines(code))
         else:
             self.write(f'$ {code}')
 


### PR DESCRIPTION
# Ren’Py 8.5 decompilation support

I’ve updated **unrpyc** to properly support decompilation for **Ren’Py 8.5**, building on the previous changes from my earlier work:
https://github.com/dukebismaya/unrpyc/releases/tag/v2.1.0

## Summary
- Added support for Ren’Py 8.5 bytecode changes
- Fixed broken and incomplete extraction on newer Ren’Py versions
- Ensured decompilation works reliably without breaking older versions

This PR makes unrpyc usable again for modern Ren’Py projects while keeping behavior consistent with earlier releases.
